### PR TITLE
Modify A03_2025-Software_Supply_Chain_Failures.md Link Error

### DIFF
--- a/2025/docs/ko/A03_2025-Software_Supply_Chain_Failures.md
+++ b/2025/docs/ko/A03_2025-Software_Supply_Chain_Failures.md
@@ -153,7 +153,7 @@
 
 ## 해당되는 CWE.
 
-* [CWE-447 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/447.html)
+* [CWE-477 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/477.html)
 
 * [CWE-1035 2017 Top 10 A9: Using Components with Known Vulnerabilities](https://cwe.mitre.org/data/definitions/1035.html)
 


### PR DESCRIPTION
본문 링크 오류

+ 참조 링크 중 "CWE-447"에 대해 원문(OWASP EN)에도 오류가 있습니다.

해당 취약점은 "Use of Obsolete Function"인 "CWE-477" 이여야 하나, 원문에 오타로 "CWE-447"과 그에 대한 링크가 걸려 있습니다.